### PR TITLE
Serialize symbol values as strings

### DIFF
--- a/notebooks/wrapper.jl
+++ b/notebooks/wrapper.jl
@@ -188,6 +188,7 @@ _preprocess(x::TimeType) = sprint(print, x)
 # ╔═╡ bc727ded-8675-420d-806e-0b49357118e5
 begin
 	_preprocess(x::Union{Bool,String,Number,Nothing,Missing}) = x
+	_preprocess(x::Symbol) = string(x)
 	_preprocess(x::Union{Tuple,AbstractArray}) = _preprocess.(x)
 	_preprocess(m::AbstractMatrix{<:Number}) = [collect(r) for r ∈ eachcol(m)]
 	_preprocess(d::Dict) = Dict{Any,Any}(k => _preprocess(v) for (k, v) in pairs(d))


### PR DESCRIPTION
This is a fix for https://github.com/JuliaPluto/PlutoPlotly.jl/issues/14.

PlotlyBase expects Julia symbols to be serialized as strings, but PlutoPlotly uses HypertextLiteral, which serializes symbols as variable references. This can be corrected by explicitly converting symbol values into strings.