### PR TITLE
add methods forward for PlotlyBase

### DIFF
--- a/notebooks/basic_tests.jl
+++ b/notebooks/basic_tests.jl
@@ -1,8 +1,6 @@
 ### A Pluto.jl notebook ###
 # v0.19.27
 
-#> custom_attrs = ["hide-enabled"]
-
 using Markdown
 using InteractiveUtils
 

--- a/notebooks/make_subplots_tests.jl
+++ b/notebooks/make_subplots_tests.jl
@@ -1,0 +1,463 @@
+### A Pluto.jl notebook ###
+# v0.19.27
+
+#> custom_attrs = ["hide-enabled"]
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 5a2798a7-d2e4-42a5-9007-6262d7c3b411
+begin
+	using PlutoDevMacros
+	using PlutoUI
+	using PlutoExtras
+end
+
+# ╔═╡ dd8ddf0a-9085-4c9d-821d-8e7ed78d33c3
+@fromparent begin
+	using ^
+	using >.HypertextLiteral
+end
+
+# ╔═╡ d1251ff9-5b35-406c-877f-28e559ac6b46
+md"""
+# Packages
+"""
+
+# ╔═╡ 8a7f8c23-488d-4133-8da6-799343fe00de
+ExtendedTableOfContents()
+
+# ╔═╡ b68cb4f2-fdbe-414f-9a6a-59786720b29f
+md"""
+# Tests
+"""
+
+# ╔═╡ 5e45b2bd-02a5-40c3-8665-ec453997193a
+md"""
+These are subplots tests taken from [https://github.com/JuliaPlots/PlotlyJS.jl/blob/master/examples/subplots.jl](https://github.com/JuliaPlots/PlotlyJS.jl/blob/master/examples/subplots.jl)
+"""
+
+# ╔═╡ 46144daf-e075-4440-8054-6293cff1f228
+md"""
+## with\_make_subplots1
+"""
+
+# ╔═╡ e90ed0c4-efb4-4f76-9093-abe381f6ef5c
+let
+    # The `shared_xaxes` argument to `make_subplots` can be used to link the x
+    # axes of subplots in the resulting figure. The `vertical_spacing` argument
+    # is used to control the vertical spacing between rows in the subplot grid.
+
+    # Here is an example that creates a figure with 3 vertically stacked
+    # subplots with linked x axes. A small vertical spacing value is used to
+    # reduce the spacing between subplot rows.
+
+	p = make_subplots(rows=3, cols=1, shared_xaxes=true, vertical_spacing=0.02)
+    add_trace!(p, scatter(x=0:2, y=10:12), row=3, col=1)
+    add_trace!(p, scatter(x=2:4, y=100:10:120), row=2, col=1)
+    add_trace!(p, scatter(x=3:5, y=1000:100:1200), row=1, col=1)
+    relayout!(p, title_text="Stacked Subplots with Shared X-Axes")
+    p
+end
+
+# ╔═╡ 96e17c39-3bfc-4372-9a3b-78dd1974f4ab
+md"""
+## with\_make_subplots2
+"""
+
+# ╔═╡ a975e09b-7ff1-4a3b-a667-62448770ab68
+let
+	# The `shared_yaxes` argument to `make_subplots` can be used to link the y
+    # axes of subplots in the resulting figure.
+
+    # Here is an example that creates a figure with a 2 x 2 subplot grid, where
+    # the y axes of each row are linked.
+
+    p = make_subplots(rows=2, cols=2, shared_yaxes=true)
+    add_trace!(p, scatter(x=0:2, y=10:12), row=1, col=1)
+    add_trace!(p, scatter(x=20:10:40, y=1:3), row=1, col=2)
+    add_trace!(p, scatter(x=3:5, y=600:100:800), row=2, col=1)
+    add_trace!(p, scatter(x=3:5, y=1000:100:1200), row=2, col=2)
+    relayout!(p, title_text="Multiple Subplots with Shared Y-Axes")
+    p
+ end
+
+# ╔═╡ 55ebabe9-e864-4905-82e7-d4ccc2eab75d
+md"""
+## with\_make_subplots3
+"""
+
+# ╔═╡ b0e75a40-158e-488d-9aa3-2ffdcfed139e
+let
+	# The `specs` argument to `make_subplots` is used to configure per-subplot
+    # options.  `specs` must be a `Matrix` with dimensions that match those
+    # provided as the `rows` and `cols` arguments. The elements of `specs` may
+    # either be `missing`, indicating no subplot should be initialized starting
+    # with this grid cell, or an instance of `Spec` containing subplot options.
+    # The `colspan` subplot option specifies the number of grid columns that the
+    # subplot starting in the given cell should occupy.  If unspecified,
+    # `colspan` defaults to 1.
+
+    # Here is an example that creates a 2 by 2 subplot grid containing 3
+    # subplots. The subplot `specs` element for position (2, 1) has a `colspan`
+    # value of 2, causing it to span the full figure width. The subplot `specs`
+    # element f or position (2, 2) is `None` because no subplot begins at this
+    # location in the grid.
+    p = make_subplots(
+        rows=2, cols=2,
+        specs=[Spec() Spec(); Spec(colspan=2) missing],
+        subplot_titles=["First Subplot" "Second Subplot"; "Third Subplot" missing]
+    )
+
+    add_trace!(p, scatter(x=[1, 2], y=[1, 2]), row=1, col=1)
+    add_trace!(p, scatter(x=[1, 2], y=[1, 2]), row=1, col=2)
+    add_trace!(p, scatter(x=[1, 2, 3], y=[2, 1, 2]), row=2, col=1)
+
+    relayout!(p, showlegend=false, title_text="Specs with Subplot Title")
+    p
+end
+
+# ╔═╡ dff22380-9496-4615-8fad-516086dadf40
+md"""
+## with\_make_subplots4
+"""
+
+# ╔═╡ 8b1ebbce-c0a2-4ac8-8cf8-52afeda5cb72
+let
+	# Here is an example that uses the `rowspan` and `colspan` subplot options
+    # to create a custom subplot layout with subplots of mixed sizes.
+    p = make_subplots(
+        rows=5, cols=2,
+        specs=[Spec() Spec(rowspan=2)
+               Spec() missing
+               Spec(rowspan=2, colspan=2) missing
+               missing missing
+               Spec() Spec()]
+    )
+
+    add_trace!(p, scatter(x=[1, 2], y=[1, 2], name="(1,1)"), row=1, col=1)
+    add_trace!(p, scatter(x=[1, 2], y=[1, 2], name="(1,2)"), row=1, col=2)
+    add_trace!(p, scatter(x=[1, 2], y=[1, 2], name="(2,1)"), row=2, col=1)
+    add_trace!(p, scatter(x=[1, 2], y=[1, 2], name="(3,1)"), row=3, col=1)
+    add_trace!(p, scatter(x=[1, 2], y=[1, 2], name="(5,1)"), row=5, col=1)
+    add_trace!(p, scatter(x=[1, 2], y=[1, 2], name="(5,2)"), row=5, col=2)
+
+    relayout!(p, height=600, width=600, title_text="specs examples")
+    p
+end
+
+# ╔═╡ 00000000-0000-0000-0000-000000000001
+PLUTO_PROJECT_TOML_CONTENTS = """
+[deps]
+PlutoDevMacros = "a0499f29-c39b-4c5c-807c-88074221b949"
+PlutoExtras = "ed5d0301-4775-4676-b788-cf71e66ff8ed"
+PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
+
+[compat]
+PlutoDevMacros = "~0.5.7"
+PlutoExtras = "~0.7.8"
+PlutoUI = "~0.7.52"
+"""
+
+# ╔═╡ 00000000-0000-0000-0000-000000000002
+PLUTO_MANIFEST_TOML_CONTENTS = """
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.9.2"
+manifest_format = "2.0"
+project_hash = "c6313dc9dc845e8656a997180043b467212250b0"
+
+[[deps.AbstractPlutoDingetjes]]
+deps = ["Pkg"]
+git-tree-sha1 = "91bd53c39b9cbfb5ef4b015e8b582d344532bd0a"
+uuid = "6e696c72-6542-2067-7265-42206c756150"
+version = "1.2.0"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.ColorTypes]]
+deps = ["FixedPointNumbers", "Random"]
+git-tree-sha1 = "eb7f0f8307f71fac7c606984ea5fb2817275d6e4"
+uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+version = "0.11.4"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.0.5+0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[deps.FixedPointNumbers]]
+deps = ["Statistics"]
+git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
+uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+version = "0.8.4"
+
+[[deps.Hyperscript]]
+deps = ["Test"]
+git-tree-sha1 = "8d511d5b81240fc8e6802386302675bdf47737b9"
+uuid = "47d2ed2b-36de-50cf-bf87-49c2cf4b8b91"
+version = "0.0.4"
+
+[[deps.HypertextLiteral]]
+deps = ["Tricks"]
+git-tree-sha1 = "c47c5fa4c5308f27ccaac35504858d8914e102f9"
+uuid = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
+version = "0.9.4"
+
+[[deps.IOCapture]]
+deps = ["Logging", "Random"]
+git-tree-sha1 = "d75853a0bdbfb1ac815478bacd89cd27b550ace6"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.2.3"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.84.0+0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.10.2+0"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.MIMEs]]
+git-tree-sha1 = "65f28ad4b594aebe22157d6fac869786a255b7eb"
+uuid = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
+version = "0.1.4"
+
+[[deps.MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "9ee1618cbf5240e6d4e0371d6f24065083f60c48"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.11"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2022.10.11"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.21+4"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "2e73fe17cac3c62ad1aebe70d44c963c3cfdc3e3"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.6.2"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "716e24b21538abc91f6205fd1d8363f39b442851"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.7.2"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.9.2"
+
+[[deps.PlutoDevMacros]]
+deps = ["HypertextLiteral", "InteractiveUtils", "MacroTools", "Markdown", "Pkg", "Random", "TOML"]
+git-tree-sha1 = "51e747644116b5806936ad355f1e32e124ec04b1"
+uuid = "a0499f29-c39b-4c5c-807c-88074221b949"
+version = "0.5.7"
+
+[[deps.PlutoExtras]]
+deps = ["AbstractPlutoDingetjes", "HypertextLiteral", "InteractiveUtils", "Markdown", "OrderedCollections", "PlutoDevMacros", "PlutoUI", "REPL"]
+git-tree-sha1 = "2ce56cb64b4c346406a855105850e7ba68d2197c"
+uuid = "ed5d0301-4775-4676-b788-cf71e66ff8ed"
+version = "0.7.8"
+
+[[deps.PlutoUI]]
+deps = ["AbstractPlutoDingetjes", "Base64", "ColorTypes", "Dates", "FixedPointNumbers", "Hyperscript", "HypertextLiteral", "IOCapture", "InteractiveUtils", "JSON", "Logging", "MIMEs", "Markdown", "Random", "Reexport", "URIs", "UUIDs"]
+git-tree-sha1 = "e47cd150dbe0443c3a3651bc5b9cbd5576ab75b7"
+uuid = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
+version = "0.7.52"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.9.0"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "Pkg", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "5.10.1+6"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.Tricks]]
+git-tree-sha1 = "aadb748be58b492045b4f56166b5188aa63ce549"
+uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
+version = "0.1.7"
+
+[[deps.URIs]]
+git-tree-sha1 = "b7a5e99f24892b6824a954199a45e9ffcc1c70f0"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.5.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.8.0+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.48.0+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+0"
+"""
+
+# ╔═╡ Cell order:
+# ╟─d1251ff9-5b35-406c-877f-28e559ac6b46
+# ╠═5a2798a7-d2e4-42a5-9007-6262d7c3b411
+# ╠═dd8ddf0a-9085-4c9d-821d-8e7ed78d33c3
+# ╠═8a7f8c23-488d-4133-8da6-799343fe00de
+# ╟─b68cb4f2-fdbe-414f-9a6a-59786720b29f
+# ╟─5e45b2bd-02a5-40c3-8665-ec453997193a
+# ╟─46144daf-e075-4440-8054-6293cff1f228
+# ╠═e90ed0c4-efb4-4f76-9093-abe381f6ef5c
+# ╟─96e17c39-3bfc-4372-9a3b-78dd1974f4ab
+# ╠═a975e09b-7ff1-4a3b-a667-62448770ab68
+# ╟─55ebabe9-e864-4905-82e7-d4ccc2eab75d
+# ╠═b0e75a40-158e-488d-9aa3-2ffdcfed139e
+# ╟─dff22380-9496-4615-8fad-516086dadf40
+# ╠═8b1ebbce-c0a2-4ac8-8cf8-52afeda5cb72
+# ╟─00000000-0000-0000-0000-000000000001
+# ╟─00000000-0000-0000-0000-000000000002

--- a/src/PlutoPlotly.jl
+++ b/src/PlutoPlotly.jl
@@ -17,6 +17,7 @@ export PlutoPlot, get_plotly_version, change_plotly_version,
 check_plotly_version, force_pluto_mathjax_local, htl_js, add_plotly_listener!,
 add_class!, remove_class!, add_js_listener!
 export plot, push_script!, prepend_cell_selector
+export make_subplots
 
 include("local_plotly_library.jl")
 

--- a/src/PlutoPlotly.jl
+++ b/src/PlutoPlotly.jl
@@ -26,6 +26,8 @@ include("mathjax.jl")
 include("preprocess.jl")
 include("js_helpers.jl")
 include("show.jl")
+# Forward methods of PlotlyBase to support PlutoPlot objects
+include("plotlybase_forward.jl")
 
 function __init__()
 	# if !is_inside_pluto()

--- a/src/main_struct.jl
+++ b/src/main_struct.jl
@@ -163,6 +163,15 @@ Base.@kwdef struct PlutoPlot
 end
 PlutoPlot(p::PlotlyBase.Plot; kwargs...) = PlutoPlot(;kwargs..., Plot = p)
 
+# Getter that extract the underlying Plot object data
+function Base.getproperty(p::PlutoPlot, s::Symbol)
+	if hasfield(Plot, s)
+		getfield(getfield(p, :Plot), s)
+	else
+		getfield(p, s)
+	end
+end
+
 function plot(args...;kwargs...) 
 	@nospecialize
 	PlutoPlot(Plot(args...;kwargs...))

--- a/src/plotlybase_forward.jl
+++ b/src/plotlybase_forward.jl
@@ -11,7 +11,10 @@ for fname in (
     :prependtraces!,
     # Layout shapes 
     :add_hrect!, :add_hline!, :add_vrect!, :add_vline!, :add_shape!,
-    :add_layout_image!
+    :add_layout_image!,
+    # generic methods from API
+    first.(PlotlyBase._layout_obj_updaters)...,
+    first.(PlotlyBase._layout_vector_updaters)...,
 )
     @eval PlotlyBase.$fname(p::PlutoPlot, args...; kwargs...) =
     PlotlyBase.$fname(p.Plot, args...; kwargs...) 
@@ -37,3 +40,13 @@ for fname in (:fork, :restyle, :relayout, :update, :addtraces, :deletetraces,
         PlutoPlot(p)
     end
 end
+
+# Here we put methods from PlotlyJS.jl
+make_subplots(;kwargs...) = plot(Layout(Subplots(;kwargs...)))
+
+@doc (@doc Subplots) make_subplots
+
+# Overload of hcat,vcat,hvcat
+Base.hcat(ps::PlutoPlot...) = PlutoPlot(hcat(map(x -> x.Plot, ps)...))
+Base.vcat(ps::PlutoPlot...) = PlutoPlot(vcat(map(x -> x.Plot, ps)...))
+Base.hvcat(rows::Tuple{Vararg{Int}}, ps::PlutoPlot...) = PlutoPlot(hvcat(rows, map(x -> x.Plot, ps)...))

--- a/src/plotlybase_forward.jl
+++ b/src/plotlybase_forward.jl
@@ -1,0 +1,39 @@
+# Methods that do not return the plot object
+for fname in (
+    :relayout!,
+    :restyle!,
+    :addtraces!,
+    :deletetraces!,
+    :movetraces!,
+    :purge!,
+    :react!,
+    :extendtraces!,
+    :prependtraces!,
+    # Layout shapes 
+    :add_hrect!, :add_hline!, :add_vrect!, :add_vline!, :add_shape!,
+    :add_layout_image!
+)
+    @eval PlotlyBase.$fname(p::PlutoPlot, args...; kwargs...) =
+    PlotlyBase.$fname(p.Plot, args...; kwargs...) 
+end
+
+# Methods that do return the plot object, (we return the PlutoPlot object in this case)
+for fname in (
+    :update!,
+    :add_trace!,
+)
+    @eval function PlotlyBase.$fname(p::PlutoPlot, args...; kwargs...) 
+        PlotlyBase.$fname(p.Plot, args...; kwargs...) 
+        p
+    end
+end
+
+# Methods that return a copy of the plot
+# Methods that do return the plot object, (we return the PlutoPlot object in this case)
+for fname in (:fork, :restyle, :relayout, :update, :addtraces, :deletetraces,
+:movetraces, :redraw, :extendtraces, :prependtraces, :purge, :react)
+    @eval function PlotlyBase.$fname(p::PlutoPlot, args...; kwargs...) 
+        p = PlotlyBase.$fname(p.Plot, args...; kwargs...) 
+        PlutoPlot(p)
+    end
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 PlotlyKaleido = "f2990250-8cf9-495f-b13a-cce12b45703c"
+Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 PlotlyKaleido = "f2990250-8cf9-495f-b13a-cce12b45703c"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"

--- a/test/basic_coverage.jl
+++ b/test/basic_coverage.jl
@@ -1,0 +1,6 @@
+using Test
+using PlutoPlotly
+
+@test force_pluto_mathjax_local() === false
+force_pluto_mathjax_local(true)
+@test force_pluto_mathjax_local() === true

--- a/test/notebook_tests.jl
+++ b/test/notebook_tests.jl
@@ -24,3 +24,13 @@ eval_in_nb(sn, expr) = WorkspaceManager.eval_fetch_in_workspace(sn, expr)
     end
     SessionActions.shutdown(ss, nb)
 end
+
+@testset "make_subplots_tests.jl" begin
+    ss = ServerSession(; options)
+    path = joinpath(notebook_dir, "make_subplots_tests.jl")
+    nb = SessionActions.open(ss, path; run_async=false)
+    for cell in nb.cells
+        @test noerror(cell)
+    end
+    SessionActions.shutdown(ss, nb)
+end

--- a/test/notebook_tests.jl
+++ b/test/notebook_tests.jl
@@ -1,0 +1,26 @@
+using Test
+import Pluto: update_save_run!, update_run!, WorkspaceManager, ClientSession,
+ServerSession, Notebook, Cell, project_relative_path, SessionActions,
+load_notebook, Configuration
+
+function noerror(cell; verbose=true)
+    if cell.errored && verbose
+        @show cell.output.body
+    end
+    !cell.errored
+end
+
+
+options = Configuration.from_flat_kwargs(; disable_writing_notebook_files=true)
+notebook_dir = joinpath(@__DIR__, "../notebooks/")
+eval_in_nb(sn, expr) = WorkspaceManager.eval_fetch_in_workspace(sn, expr)
+
+@testset "basic_tests.jl" begin
+    ss = ServerSession(; options)
+    path = joinpath(notebook_dir, "basic_tests.jl")
+    nb = SessionActions.open(ss, path; run_async=false)
+    for cell in nb.cells
+        @test noerror(cell)
+    end
+    SessionActions.shutdown(ss, nb)
+end

--- a/test/plotlybase_api.jl
+++ b/test/plotlybase_api.jl
@@ -1,0 +1,364 @@
+using Test
+using DataFrames
+using PlutoPlotly
+
+function fresh_data()
+    t1 = scatter(;y=[1, 2, 3])
+    t2 = scatter(;y=[10, 20, 30])
+    t3 = scatter(;y=[100, 200, 300])
+    l = Layout(;title="Foo")
+    p = Plot([copy(t1), copy(t2), copy(t3)], copy(l)) |> PlutoPlot
+    t1, t2, t3, l, p
+end
+
+@testset "Test api methods on Plot" begin
+
+    # @testset "test helpers" begin
+    #     @test PlotlyBase._prep_restyle_vec_setindex([1, 2], 2) == [1, 2]
+    #     @test PlotlyBase._prep_restyle_vec_setindex([1, 2], 3) == [1, 2, 1]
+    #     @test PlotlyBase._prep_restyle_vec_setindex([1, 2], 4) == [1, 2, 1, 2]
+
+    #     @test PlotlyBase._prep_restyle_vec_setindex((1, [42, 4]), 2) == Any[1, [42, 4]]
+    #     @test PlotlyBase._prep_restyle_vec_setindex((1, [42, 4]), 3) == Any[1, [42, 4], 1]
+    #     @test PlotlyBase._prep_restyle_vec_setindex((1, [42, 4]), 4) == Any[1, [42, 4], 1, [42, 4]]
+    # end
+
+    # @testset "test _update_fields" begin
+    #     t1, t2, t3, l, p = fresh_data()
+    #     # test dict version
+    #     o = copy(t1)
+    #     PlotlyBase._update_fields(o, 1, Dict{Symbol,Any}(:foo => "Bar"))
+    #     @test o["foo"] == "Bar"
+    #     # kwarg version
+    #     PlotlyBase._update_fields(o, 1; foo="Foo")
+    #     @test o["foo"] == "Foo"
+
+    #     # dict + kwarg version. Make sure dict gets through w/out replacing _
+    #     PlotlyBase._update_fields(o, 1, Dict{Symbol,Any}(:fuzzy_wuzzy => "Bear");
+    #                             fuzzy_wuzzy="?")
+    #     @test o.fields[:fuzzy_wuzzy] == "Bear"
+    #     @test isa(o.fields[:fuzzy], Dict)
+    #     @test o["fuzzy.wuzzy"] == "?"
+    # end
+
+    @testset "test relayout!" begin
+        t1, t2, t3, l, p = fresh_data()
+        # test on plot object
+        relayout!(p, Dict{Symbol,Any}(:title => "Fuzzy"); xaxis_title="wuzzy")
+        @test p.layout["title"] == "Fuzzy"
+        @test p.layout["xaxis.title.text"] == "wuzzy"
+
+        # test on layout object
+        relayout!(l, Dict{Symbol,Any}(:title => "Fuzzy"); xaxis_title="wuzzy")
+        @test l["title"] == "Fuzzy"
+        @test l["xaxis.title.text"] == "wuzzy"
+        end
+
+    @testset "test react!" begin
+        t1, t2, t3, l, p = fresh_data()
+        t4 = bar(x=[1, 2, 3], y=[42, 242, 142])
+        l2 = Layout(xaxis_title="wuzzy")
+        react!(p, [t4], l2)
+        
+        @test length(p.data) == 1
+        @test p.data[1] == t4
+        @test p.layout == l2
+    end
+
+    @testset "test purge!" begin
+        t1, t2, t3, l, p = fresh_data()
+        purge!(p)
+        @test p.data == []
+        @test p.layout == Layout()
+    end
+
+    @testset "test restyle!" begin
+        t1, t2, t3, l, p = fresh_data()
+        # test on trace object
+        restyle!(t1, 1, Dict{Symbol,Any}(:opacity => 0.4); marker_color="red")
+        @test t1["opacity"] == 0.4
+        @test t1["marker.color"] == "red"
+
+        # test for single trace in plot
+        restyle!(p, 2, Dict{Symbol,Any}(:opacity => 0.4); marker_color="red")
+        @test p.data[2]["opacity"] == 0.4
+        @test p.data[2]["marker.color"] == "red"
+
+        # test for multiple trace in plot
+        restyle!(p, [1, 3], Dict{Symbol,Any}(:opacity => 0.9); marker_color="blue")
+        @test p.data[1]["opacity"] == 0.9
+        @test p.data[1]["marker.color"] == "blue"
+        @test p.data[3]["opacity"] == 0.9
+        @test p.data[3]["marker.color"] == "blue"
+
+        # test for all traces in plot
+        restyle!(p, 1:3, Dict{Symbol,Any}(:opacity => 0.42); marker_color="white")
+        for i in 1:3
+        @test p.data[i]["opacity"] == 0.42
+            @test p.data[i]["marker.color"] == "white"
+        end
+
+        @testset "test restyle with vector attributes applied to all traces" begin
+            # test that short arrays repeat
+            restyle!(p, marker_color=["red", "green"])
+            @test p.data[1]["marker.color"] == "red"
+            @test p.data[2]["marker.color"] == "green"
+            @test p.data[3]["marker.color"] == "red"
+
+            # test that array of arrays is repeated and applied everywhere
+            restyle!(p, marker_color=(["red", "green"],))
+            @test p.data[1]["marker.color"] == ["red", "green"]
+            @test p.data[2]["marker.color"] == ["red", "green"]
+            @test p.data[3]["marker.color"] == ["red", "green"]
+
+            # test that array of arrays is repeated and applied everywhere
+            restyle!(p, marker_color=(["red", "green"], "blue"))
+            @test p.data[1]["marker.color"] == ["red", "green"]
+            @test p.data[2]["marker.color"] == "blue"
+            @test p.data[3]["marker.color"] == ["red", "green"]
+        end
+
+        @testset "test restyle with vector attributes applied to vector of traces" begin
+            # test that short arrays repeat
+            restyle!(p, 1:3, marker_color=["red", "green"])
+            @test p.data[1]["marker.color"] == "red"
+            @test p.data[2]["marker.color"] == "green"
+            @test p.data[3]["marker.color"] == "red"
+
+            # test that array of arrays is repeated and applied everywhere
+            restyle!(p, 1:3, marker_color=(["red", "green"],))
+            @test p.data[1]["marker.color"] == ["red", "green"]
+            @test p.data[2]["marker.color"] == ["red", "green"]
+            @test p.data[3]["marker.color"] == ["red", "green"]
+
+            # test that array of arrays is repeated and applied everywhere
+            restyle!(p, 1:3, marker_color=(["red", "green"], "blue"))
+            @test p.data[1]["marker.color"] == ["red", "green"]
+            @test p.data[2]["marker.color"] == "blue"
+            @test p.data[3]["marker.color"] == ["red", "green"]
+        end
+
+        @testset "test restyle with vector attributes applied to trace object" begin
+            restyle!(t1, 1, x=[1, 2, 3])
+            @test t1["x"] == 1
+
+            restyle!(t1, 1, x=([1, 2, 3],))
+            @test t1["x"] == [1, 2, 3]
+        end
+
+        @testset "test restyle with vector attributes applied to single trace " begin
+            restyle!(p, 2, x=[1, 2, 3])
+            @test p.data[2]["x"] == 1
+
+            restyle!(p, 2, x=([1, 2, 3],))
+            @test p.data[2]["x"] == [1, 2, 3]
+        end
+    end
+
+    @testset "test addtraces!" begin
+        t1, t2, t3, l, p = fresh_data()
+        p2 = Plot()
+
+        # test add one trace to end
+        addtraces!(p2, t1)
+        @test length(p2.data) == 1
+        @test p2.data[1] == t1
+
+        # test add two traces to end
+        addtraces!(p2, t2, t3)
+        @test length(p2.data) == 3
+        @test p2.data[2] == t2
+        @test p2.data[3] == t3
+
+        # test add one trace middle
+        t4 = scatter()
+        addtraces!(p2, 2, t4)
+        @test length(p2.data) == 4
+        @test p2.data[1] == t1
+        @test p2.data[2] == t4
+        @test p2.data[3] == t2
+        @test p2.data[4] == t3
+
+        # test add multiple trace middle
+        t5 = scatter()
+        t6 = scatter()
+        addtraces!(p2, 2, t5, t6)
+        @test length(p2.data) == 6
+        @test p2.data[1] == t1
+        @test p2.data[2] == t5
+        @test p2.data[3] == t6
+        @test p2.data[4] == t4
+        @test p2.data[5] == t2
+        @test p2.data[6] == t3
+    end
+
+    @testset "test deletetraces!" begin
+        t1, t2, t3, l, p = fresh_data()
+
+        # test delete one trace
+        deletetraces!(p, 2)
+        @test length(p.data) == 2
+        @test p.data[1]["y"] == t1["y"]
+        @test p.data[2]["y"] == t3["y"]
+
+        # test delete multiple traces
+        deletetraces!(p, 1, 2)
+        @test length(p.data) == 0
+    end
+
+    @testset "test movetraces!" begin
+        t1, t2, t3, l, p = fresh_data()
+
+        # test move one trace to end
+        movetraces!(p, 2)  # now 1 3 2
+        @test p.data[1]["y"] == t1["y"]
+        @test p.data[2]["y"] == t3["y"]
+        @test p.data[3]["y"] == t2["y"]
+
+        # test move two traces to end
+        movetraces!(p, 1, 2) # now 2 1 3
+        @test p.data[1]["y"] == t2["y"]
+        @test p.data[2]["y"] == t1["y"]
+        @test p.data[3]["y"] == t3["y"]
+
+        # test move from/to
+        movetraces!(p, [1, 3], [2, 1])  # 213 -> 123 -> 312
+        @test p.data[1]["y"] == t3["y"]
+        @test p.data[2]["y"] == t1["y"]
+        @test p.data[3]["y"] == t2["y"]
+    end
+
+
+    @testset "test update_XXX! layout props" begin
+        t1, t2, t3, l, p = fresh_data()
+        p2 = [p p]
+        @test PlotlyBase._isempty(p2.layout.xaxis2_showticklabels)
+        @test PlotlyBase._isempty(p2.layout.xaxis_showticklabels)
+        update_xaxes!(p2, showticklabels=true)
+
+        @test p2.layout.xaxis2_showticklabels
+        @test p2.layout.xaxis_showticklabels
+        
+        p3 = [p; p]
+        @test PlotlyBase._isempty(p3.layout.yaxis2_showticklabels)
+        @test PlotlyBase._isempty(p3.layout.yaxis_showticklabels)
+        update_yaxes!(p3, showticklabels=true)
+
+        @test p3.layout.yaxis2_showticklabels
+        @test p3.layout.yaxis_showticklabels
+
+
+        for ann in p2.layout.annotations
+            @test ann[:font][:size] != 1
+        end
+        update_annotations!(p2, font_size=1)
+        for ann in p2.layout.annotations
+            @test ann[:font][:size] == 1
+        end
+    end
+
+    @testset "add_trace!" begin
+        df = stack(DataFrame(x=1:10, one=1, two=2, three=3, four=4, five=5, six=6, seven=7), Not(:x))
+        p = Plot(df, x=:x, y=:value, facet_col=:variable, facet_col_wrap=2)
+        @test length(p.data) == 7
+        @test size(p.layout.subplots.grid_ref) == (4, 2)
+
+        add_trace!(p, scatter(x=1:4, y=(1:4).^2), row="all")  # add to all rows in col 1
+        @test length(p.data) == 11
+
+        add_trace!(p, scatter(x=1:4, y=(1:4).^2), col="all")  # add to all cols in row 1
+        @test length(p.data) == 13
+
+        add_trace!(p, scatter(x=1:4, y=(1:4).^2), col=Colon(), row=3)  # add to all cols in row 3
+        @test length(p.data) == 15
+
+        add_trace!(p, scatter(x=1:4, y=(1:4).^2), row="all", col="all")
+        @test length(p.data) == 23  # adds 8 because we get full 4x2 grid
+    end
+end
+
+@testset "add_shape!" begin
+    p = Plot(Layout(Subplots(rows=2, cols=2)))
+    add_trace!(p, scatter(y=rand(4)), row="all", col="all")
+    add_shape!(p, rect(x0=2, x1=4, y0=0.2, y1=0.5, line_color="purple"), row="all", col="all")
+    @test length(p.layout.shapes) == 4
+    @test all(s -> s.type == "rect", p.layout.shapes)
+    @test all(s -> s.line_color == "purple", p.layout.shapes)
+
+    add_shape!(p, line(x0=1, x1=3, y0=.5, y1=.9, line_color="yellow"), row="all", col=2)
+    @test length(p.layout.shapes) == 6
+    @test all(s -> s.type == "line", p.layout.shapes[5:6])
+    @test all(s -> s.line_color == "yellow", p.layout.shapes[5:6])
+
+    add_shape!(p, circle(x0=4, y0=0.2, x1=5, y1=0.7, line_color="black"), row=2)
+    @test length(p.layout.shapes) == 8
+    @test all(s -> s.type == "circle", p.layout.shapes[7:8])
+    @test all(s -> s.line_color == "black", p.layout.shapes[7:8])
+end
+
+@testset "unpack namedtuple type figure" begin
+    fig = (
+        data = [
+            (type = "scatter", x = 1:4, y = rand(4), mode = "markers", marker = (line = (color = "red", width = 2), size = 8)),
+            (type = "scatter", x = 1:4, y = rand(4))
+        ],
+        layout = (hovermode = "unified",)
+    )
+    plots = Plot[
+        Plot(fig)
+        Plot((layout = fig.layout, data = fig.data))
+        Plot((;frames=[], fig...))
+        Plot((;fig..., frames=[]))
+        Plot((layout = fig.layout, frames = [], data = fig.data))
+        Plot((data = fig.data, frames = [], layout = fig.layout))
+    ]
+    p1 = plots[1];
+    for p2 in plots[2:end]
+        @test p1.layout == p2.layout
+        @test p1.data == p2.data
+    end
+    @test p1.data[1] isa GenericTrace
+    @test p1.data[1].marker isa Dict
+    @test p1.data[1].marker_line isa Dict
+    @test p1.data[1].marker_line_width isa Number
+
+end
+
+@testset "subplots" begin
+
+    labels = ["1st", "2nd", "3rd", "4th", "5th"]
+
+    # Define color sets of paintings
+    night_colors = ["rgb(56, 75, 126)", "rgb(18, 36, 37)", "rgb(34, 53, 101)",
+                    "rgb(36, 55, 57)", "rgb(6, 4, 4)"]
+    sunflowers_colors = ["rgb(177, 127, 38)", "rgb(205, 152, 36)", "rgb(99, 79, 37)",
+                        "rgb(129, 180, 179)", "rgb(124, 103, 37)"]
+    irises_colors = ["rgb(33, 75, 99)", "rgb(79, 129, 102)", "rgb(151, 179, 100)",
+                    "rgb(175, 49, 35)", "rgb(36, 73, 147)"]
+    cafe_colors =  ["rgb(146, 123, 21)", "rgb(177, 180, 34)", "rgb(206, 206, 40)",
+                    "rgb(175, 51, 21)", "rgb(35, 36, 21)"]
+
+    # Create subplots, using "domain" type for pie charts
+    layout = Layout(Subplots(rows=2, cols=2, specs=fill(Spec(kind="domain"), 2, 2)))
+    fig = Plot(layout)
+    
+
+    # Define pie charts
+    add_trace!(fig, pie(labels=labels, values=[38, 27, 18, 10, 7], name="Starry Night",
+                        marker_colors=night_colors), row=1, col=1)
+    add_trace!(fig, pie(labels=labels, values=[28, 26, 21, 15, 10], name="Sunflowers",
+                        marker_colors=sunflowers_colors), row=1, col=2)
+    add_trace!(fig, pie(labels=labels, values=[38, 19, 16, 14, 13], name="Irises",
+                        marker_colors=irises_colors), row=2, col=1)
+    add_trace!(fig, pie(labels=labels, values=[31, 24, 19, 18, 8], name="The Night Café",
+                        marker_colors=cafe_colors), row=2, col=2)
+
+    # Tune layout and hover info
+    restyle!(fig, hoverinfo="label+percent+name", textinfo="none")
+    relayout!(fig, title_text="Van Gogh: 5 Most Prominent Colors Shown Proportionally",
+            showlegend=false)
+
+    @test !isempty(fig.data[1].domain_y)
+    @test !isempty(fig.data[1].domain_x)
+
+end

--- a/test/plotlybase_api.jl
+++ b/test/plotlybase_api.jl
@@ -259,7 +259,7 @@ end
 
     @testset "add_trace!" begin
         df = stack(DataFrame(x=1:10, one=1, two=2, three=3, four=4, five=5, six=6, seven=7), Not(:x))
-        p = Plot(df, x=:x, y=:value, facet_col=:variable, facet_col_wrap=2)
+        p = plot(df, x=:x, y=:value, facet_col=:variable, facet_col_wrap=2)
         @test length(p.data) == 7
         @test size(p.layout.subplots.grid_ref) == (4, 2)
 
@@ -278,7 +278,7 @@ end
 end
 
 @testset "add_shape!" begin
-    p = Plot(Layout(Subplots(rows=2, cols=2)))
+    p = plot(Layout(Subplots(rows=2, cols=2)))
     add_trace!(p, scatter(y=rand(4)), row="all", col="all")
     add_shape!(p, rect(x0=2, x1=4, y0=0.2, y1=0.5, line_color="purple"), row="all", col="all")
     @test length(p.layout.shapes) == 4
@@ -304,13 +304,13 @@ end
         ],
         layout = (hovermode = "unified",)
     )
-    plots = Plot[
-        Plot(fig)
-        Plot((layout = fig.layout, data = fig.data))
-        Plot((;frames=[], fig...))
-        Plot((;fig..., frames=[]))
-        Plot((layout = fig.layout, frames = [], data = fig.data))
-        Plot((data = fig.data, frames = [], layout = fig.layout))
+    plots = PlutoPlot[
+        plot(fig)
+        plot((layout = fig.layout, data = fig.data))
+        plot((;frames=[], fig...))
+        plot((;fig..., frames=[]))
+        plot((layout = fig.layout, frames = [], data = fig.data))
+        plot((data = fig.data, frames = [], layout = fig.layout))
     ]
     p1 = plots[1];
     for p2 in plots[2:end]
@@ -340,7 +340,7 @@ end
 
     # Create subplots, using "domain" type for pie charts
     layout = Layout(Subplots(rows=2, cols=2, specs=fill(Spec(kind="domain"), 2, 2)))
-    fig = Plot(layout)
+    fig = plot(layout)
     
 
     # Define pie charts
@@ -361,4 +361,15 @@ end
     @test !isempty(fig.data[1].domain_y)
     @test !isempty(fig.data[1].domain_x)
 
+end
+
+@testset "Random Additional Coverage Tests" begin
+        t1, t2, t3, l, p = fresh_data()
+        # test on plot object
+        p2 = relayout(p, Dict{Symbol,Any}(:title => "Fuzzy"); xaxis_title="wuzzy")
+        relayout!(p, Dict{Symbol,Any}(:title => "Fuzzy"); xaxis_title="wuzzy")
+        @test p2.layout == p.layout
+        @test p2.layout !== p.layout
+
+        @test_nowarn [p p;p p]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
 using SafeTestsets
 
 @safetestset "Extensions" begin include("extensions.jl") end
+@safetestset "Pluto Tests" begin include("notebook_tests.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using SafeTestsets
 @safetestset "Extensions" begin include("extensions.jl") end
 @safetestset "PlotlyBase API" begin include("plotlybase_api.jl") end
 @safetestset "Pluto Tests" begin include("notebook_tests.jl") end
+@safetestset "Coverage Improvements" begin include("basic_coverage.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using SafeTestsets
 
 @safetestset "Extensions" begin include("extensions.jl") end
+@safetestset "PlotlyBase API" begin include("plotlybase_api.jl") end
 @safetestset "Pluto Tests" begin include("notebook_tests.jl") end


### PR DESCRIPTION
This forwards the convenience methods from PlotlyBase so that they can directly be called also on PlutoPlot objects.

Should fix #11 

Added features:
- All of the API methods defined on PlotlyBase for `Plot` objects are defined as forward also for `PlutoPlot` objects
- `Base.getproperty` is now directly accessing the `Plot` fields (since there is no duplicate field name between `PlutoPlot` and `Plot` tyeps
- This packages now defines and re-export `make_subplots` like in PlotlyJS