### PR TITLE
convert AbstractString to String and Real to Float32

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,6 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [weakdeps]

--- a/src/preprocess.jl
+++ b/src/preprocess.jl
@@ -28,7 +28,7 @@ _preprocess(s::AbstractString) = String(s)
 
 _preprocess(x::Real) = Float32(x)
 
-_preprocess(x::Union{Bool,String,Number,Nothing,Missing}) = x
+_preprocess(x::Union{Bool,String,Nothing,Missing}) = x
 _preprocess(x::Symbol) = string(x)
 _preprocess(x::Union{Tuple,AbstractArray}) = _preprocess.(x)
 _preprocess(A::AbstractArray{<:Number, N}) where N = if N == 1

--- a/src/preprocess.jl
+++ b/src/preprocess.jl
@@ -26,6 +26,8 @@ _preprocess(x::TimeType) = sprint(print, x) # For handling datetimes
 
 _preprocess(s::AbstractString) = String(s)
 
+_preprocess(x::Real) = Float32(x)
+
 _preprocess(x::Union{Bool,String,Number,Nothing,Missing}) = x
 _preprocess(x::Symbol) = string(x)
 _preprocess(x::Union{Tuple,AbstractArray}) = _preprocess.(x)

--- a/src/preprocess.jl
+++ b/src/preprocess.jl
@@ -24,6 +24,8 @@ end
 _preprocess(x) = PlotlyBase.JSON.lower(x) # Default
 _preprocess(x::TimeType) = sprint(print, x) # For handling datetimes
 
+_preprocess(s::AbstractString) = String(s)
+
 _preprocess(x::Union{Bool,String,Number,Nothing,Missing}) = x
 _preprocess(x::Symbol) = string(x)
 _preprocess(x::Union{Tuple,AbstractArray}) = _preprocess.(x)

--- a/test/basic_coverage.jl
+++ b/test/basic_coverage.jl
@@ -10,7 +10,7 @@ force_pluto_mathjax_local(true)
 
 @test ColorScheme([Colors.RGB(0.0, 0.0, 0.0), Colors.RGB(1.0, 1.0, 1.0)],
 "custom", "twotone, black and white") |> _preprocess == [(0.0, "rgb(0,0,0)"), (1.0, "rgb(255,255,255)")]
-@test _preprocess("asda"[1:3]) === "asd"
+@test _preprocess(SubString("asda",1:3)) === "asd"
 @test _preprocess(:lol) === "lol"
 @test _preprocess(true) === true
 @test _preprocess(Cycler((1,2))) == [1,2]

--- a/test/basic_coverage.jl
+++ b/test/basic_coverage.jl
@@ -1,6 +1,19 @@
 using Test
 using PlutoPlotly
+using PlutoPlotly: _preprocess
+using PlutoPlotly.PlotlyBase: ColorScheme, Colors, Cycler
+
 
 @test force_pluto_mathjax_local() === false
 force_pluto_mathjax_local(true)
 @test force_pluto_mathjax_local() === true
+
+@test ColorScheme([Colors.RGB(0.0, 0.0, 0.0), Colors.RGB(1.0, 1.0, 1.0)],
+"custom", "twotone, black and white") |> _preprocess == [(0.0, "rgb(0,0,0)"), (1.0, "rgb(255,255,255)")]
+@test _preprocess("asda"[1:3]) === "asd"
+@test _preprocess(:lol) === "lol"
+@test _preprocess(true) === true
+@test _preprocess(Cycler((1,2))) == [1,2]
+@test _preprocess(1) === 1.0f0
+@test _preprocess(L"3+2") === raw"$3+2$"
+


### PR DESCRIPTION
This PR adds two `_preprocess` methods. 
- one to convert AbstractStrings to Strings (to avoid potential errors with `assertpackable`)
- one to convert each Real number to Float32. This closes #4 

The tests for Float32 did not show much improvement in rendering speed, but static html download is halved so that's a plus.

The notebook code for test
```julia
# ╔═╡ 377f5579-c86e-4ad6-9f0a-564118dcac05
@bind a Clock(1)

# ╔═╡ 99b7beb8-df1e-4827-9b13-cc9e5f6ff102
p = let
	a
N = 100000
plot(scattergl(
    x=randn(N), y=randn(N), mode="markers",
    marker=attr(color=randn(N), colorscale="Viridis", line_width=1)
))
end
```

![image](https://github.com/JuliaPluto/PlutoPlotly.jl/assets/12846528/1d349a58-7a55-4e70-bd3a-f1032ef8d8e0)
