### PR TITLE
Force an old version of the Kaleido C library for windows tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,11 @@
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Kaleido_jll = "f7e6163d-2fa5-5f23-b69c-1db539e41963"
 PlotlyKaleido = "f2990250-8cf9-495f-b13a-cce12b45703c"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[compat]
+Kaleido_jll = "0.1"


### PR DESCRIPTION
It seems that many people face problems with kaleido on windows hanging:
- https://github.com/plotly/Kaleido/issues/134
- https://github.com/plotly/Kaleido/issues/98
- https://github.com/JuliaPlots/PlotlyKaleido.jl/issues/13
- https://github.com/JuliaPlots/PlotlyJS.jl/issues/473

The suggestion in the issues in the main Kaleido repository above was to downgrade the kaleido library to 0.1 in windows to make this work, and preliminary tests seem to validate this also from Julia.

It is not necessary to downgrade PlotlyKaleido itself, but is sufficient to introduce in the Project/environment the Kaleido_jll package tagged to the 0.1 version.
This seems to fix the tests and should also be a way of fixing the PlotlyKaleido library on windows machines