### PR TITLE
TOML.print into buffer before writing to file

### DIFF
--- a/src/local_plotly_library.jl
+++ b/src/local_plotly_library.jl
@@ -39,9 +39,9 @@ $pluto_path") : continue)
 end
 
 function update_versions_file()
-    open(VERSIONS_PATH, "w") do io
+    write(VERSIONS_PATH, sprint() do io
         TOML.print(io, VERSIONS_DICT[])
-    end
+    end)
 end
 function get_esm_url(v)
     v = string(v)


### PR DESCRIPTION
You usually want to TOML.print into a buffer before writing to the file, because TOML might throw in the middle of a `TOML.print`, and you don't want to end up with a half-written toml file in this case.