### PR TITLE
fix missing Vararg

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,15 +24,12 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [0.6.4] - 2025-07-17
+This is the first release we track in the changelog. Changes are with respect to 0.6.3
+
+### Fixed
+- Fixed a bug in the preprocess which was not correctly handing nested object of type `Plotly.HasFields`

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoPlotly"
 uuid = "8e989ff0-3d88-8e9f-f020-2b208a939ff0"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"

--- a/src/preprocess.jl
+++ b/src/preprocess.jl
@@ -105,7 +105,7 @@ function _process_with_names(d::Dict{Symbol}, fl::Val, @nospecialize(args::Varar
     Dict{Symbol,Any}(k => _process_with_names(v, fl, AttrName(k), args...) for (k, v) in pairs(d))
 end
 # We have a separate one because it seems to reduce allocations
-_process_with_names(a::PlotlyBase.HasFields, fl::Val, @nospecialize(args::AttrName)) =
+_process_with_names(a::PlotlyBase.HasFields, fl::Val, @nospecialize(args::Vararg{AttrName})) =
     _process_with_names(a.fields, fl, args...)
 
 # Templates

--- a/test/preprocess.jl
+++ b/test/preprocess.jl
@@ -1,5 +1,5 @@
 @testitem "Preprocess" begin
-    using PlutoPlotly: _process_with_names, AttrName
+    using PlutoPlotly: _process_with_names, AttrName, _preprocess, AttrName
     l = Layout(;
         title_text = "asd",
         title_x = 0.5
@@ -23,4 +23,8 @@
     )
     d = _process_with_names(l)
     @test d[:sliders][1][:steps][1] isa Dict{Symbol}
+
+    # Misc coverage
+    @test !(_preprocess(1im) isa Complex)
+    @test length((AttrName(:x)...,)) == 1
 end

--- a/test/preprocess.jl
+++ b/test/preprocess.jl
@@ -9,4 +9,18 @@
     tit = d[:title]
     @test haskey(tit, :text) && tit[:text] == "asd"
     @test haskey(tit, :x) && tit[:x] == 0.5
+
+    # Add a test for nested attrs (Cause of issue #65)
+    l = Layout(;
+        sliders = [attr(;
+            steps = [
+                attr(;
+                    label = "Step 1",
+                    value = 1
+                )
+            ]
+        )]
+    )
+    d = _process_with_names(l)
+    @test d[:sliders][1][:steps][1] isa Dict{Symbol}
 end


### PR DESCRIPTION
This PR fixes a bug in the code update since v0.6 which was not correctly handling objects of type `PlotlyBase.HasFields` if they were nested and not at the first level.

Closes #65 