### PR TITLE
Decouple plot JS core from Pluto (Phase A)

### DIFF
--- a/src/js/clipboard.js
+++ b/src/js/clipboard.js
@@ -1,7 +1,7 @@
 // Injected as part of the plot <script> (see src/show.jl); runs in the shared
 // scope of the concatenated script. Expects to already be in scope:
-//   Julia preamble: plot_obj, Plotly, CONTAINER, PLOT, firstRun,
-//                   original_width, original_height, remove_container_size
+//   Julia preamble: Plotly, CONTAINER, PLOT, firstRun
+//   on CONTAINER  : plot_obj, original_width, original_height, remove_container_size
 //   Pluto runtime : html
 //   resizer.js    : getSizeData, computeContainerSize
 // Exposes for resizer.js: CLIPBOARD_HEADER, config_spans, and the
@@ -18,11 +18,11 @@ function delay(ms) {
 }
 
 function getImageOptions() {
-  const o = plot_obj.config.toImageButtonOptions ?? {};
+  const o = CONTAINER.plot_obj.config.toImageButtonOptions ?? {};
   return {
     format: o.format ?? "png",
-    width: o.width ?? original_width,
-    height: o.height ?? original_height,
+    width: o.width ?? CONTAINER.original_width,
+    height: o.height ?? CONTAINER.original_height,
     scale: o.scale ?? 1,
     filename: o.filename ?? "newplot",
   };
@@ -154,14 +154,14 @@ function initializeConfigValueSpan(span, key) {
   const container = span.closest(".clipboard-span");
   Object.defineProperty(span, "value", {
     get: () => {
-      return plot_obj.config.toImageButtonOptions[key];
+      return CONTAINER.plot_obj.config.toImageButtonOptions[key];
     },
     set: (val) => {
       // if undefined is passed, we remove the entry from the options
       if (val === undefined) {
-        delete plot_obj.config.toImageButtonOptions[key];
+        delete CONTAINER.plot_obj.config.toImageButtonOptions[key];
       } else {
-        plot_obj.config.toImageButtonOptions[key] = val;
+        CONTAINER.plot_obj.config.toImageButtonOptions[key] = val;
       }
       checkConfigSync(container);
     },
@@ -195,8 +195,8 @@ for (const [key, value] of Object.entries(getImageOptions())) {
   container.key = key;
   config_spans[key] = container;
   if (firstRun) {
-    plot_obj.config.toImageButtonOptions =
-      plot_obj.config.toImageButtonOptions ?? {};
+    CONTAINER.plot_obj.config.toImageButtonOptions =
+      CONTAINER.plot_obj.config.toImageButtonOptions ?? {};
     // We do the initialization of the value span
     initializeUIValueSpan(ui_value_span, key, value);
     // Then we initialize the config value
@@ -359,7 +359,7 @@ function unpop_container(cl) {
   CONTAINER.classList.toggle(cl, false);
   // We fix the height back to the value it had before popout, also setting the flag to signal that upon first resize we remove the fixed inline-style
   CONTAINER.style.height = container_rect.height + "px";
-  remove_container_size = true;
+  CONTAINER.remove_container_size = true;
   // We set the other fixed inline-styles to null
   CONTAINER.style.width = "";
   CONTAINER.style.top = "";
@@ -459,13 +459,13 @@ function DualClick(single_func, dbl_func) {
 }
 
 // We remove the default download image button
-plot_obj.config.modeBarButtonsToRemove = union(
-  plot_obj.config.modeBarButtonsToRemove,
+CONTAINER.plot_obj.config.modeBarButtonsToRemove = union(
+  CONTAINER.plot_obj.config.modeBarButtonsToRemove,
   ["toImage"]
 );
 // We add the custom button to the modebar
-plot_obj.config.modeBarButtonsToAdd = union(
-  plot_obj.config.modeBarButtonsToAdd,
+CONTAINER.plot_obj.config.modeBarButtonsToAdd = union(
+  CONTAINER.plot_obj.config.modeBarButtonsToAdd,
   [
     {
       name: "Copy PNG to Clipboard",

--- a/src/js/clipboard.js
+++ b/src/js/clipboard.js
@@ -1,11 +1,10 @@
-// Injected as part of the plot <script> (see src/show.jl); runs in the shared
-// scope of the concatenated script. Expects to already be in scope:
-//   Julia preamble: Plotly, CONTAINER, PLOT, firstRun
-//   on CONTAINER  : plot_obj, original_width, original_height, remove_container_size
-//   Pluto runtime : html
-//   resizer.js    : getSizeData, computeContainerSize
-// Exposes for resizer.js: CLIPBOARD_HEADER, config_spans, and the
-// CONTAINER.isPoppedOut()/popOut() helpers.
+// Clipboard / export-header behaviour for the plot. Wrapped in one function so
+// it pollutes nothing in the shared script scope; all per-plot state lives on
+// the passed-in CONTAINER. Reads `html` (html.js) and getSizeData /
+// computeContainerSize (resizer.js); exposes CONTAINER.CLIPBOARD_HEADER,
+// CONTAINER.config_spans and CONTAINER.popOut for resizer.js.
+function addClipboardFunctionality(CONTAINER, firstRun) {
+  const { Plotly, PLOT } = CONTAINER;
 
 // Minimal vanilla replacement for lodash _.union (unique, order-preserving)
 function union(a, b) {
@@ -57,6 +56,7 @@ const CLIPBOARD_HEADER =
       ></span>
     </div>`
   );
+CONTAINER.CLIPBOARD_HEADER = CLIPBOARD_HEADER;
 
 function checkConfigSync(container) {
   const valid_classes = [
@@ -218,6 +218,7 @@ for (const [key, value] of Object.entries(getImageOptions())) {
     });
   }
 }
+CONTAINER.config_spans = config_spans;
 
 // These objects will contain the default value
 
@@ -241,11 +242,6 @@ if (firstRun) {
   };
   unset_button.onclick = unsetImageOptions;
 }
-
-// We add a function to check if the clipboard is popped out
-CONTAINER.isPoppedOut = () => {
-  return CONTAINER.classList.contains("popped-out");
-};
 
 CLIPBOARD_HEADER.onmousedown = function (event) {
   if (event.target.matches("span.clipboard-value")) {
@@ -389,9 +385,9 @@ function popout_container(opts) {
   };
   // We have to save the pad data before popping so we can resize precisely
   const pad = {};
-  pad.unpopped = getSizeData().container_pad;
+  pad.unpopped = getSizeData(CONTAINER).container_pad;
   CONTAINER.classList.toggle("popped-out", true);
-  pad.popped = getSizeData().container_pad;
+  pad.popped = getSizeData(CONTAINER).container_pad;
   // We do top and left based on the current rect
   for (const key of ["top", "left"]) {
     const start_val = target_container_size[key] ?? container_rect[key];
@@ -405,7 +401,7 @@ function popout_container(opts) {
     }
   }
   // We compute the width and height depending on eventual config data
-  const csz = computeContainerSize({
+  const csz = computeContainerSize(CONTAINER, {
     width:
       target_plot_size.width ??
       config_spans.width.config_value ??
@@ -489,3 +485,4 @@ CONTAINER.plot_obj.config.modeBarButtonsToAdd = union(
     },
   ]
 );
+}

--- a/src/js/clipboard.js
+++ b/src/js/clipboard.js
@@ -3,10 +3,14 @@
 //   Julia preamble: plot_obj, Plotly, CONTAINER, PLOT, firstRun,
 //                   original_width, original_height, remove_container_size
 //   Pluto runtime : html
-//   lodash-es     : _
 //   resizer.js    : getSizeData, computeContainerSize
 // Exposes for resizer.js: CLIPBOARD_HEADER, config_spans, and the
 // CONTAINER.isPoppedOut()/popOut() helpers.
+
+// Minimal vanilla replacement for lodash _.union (unique, order-preserving)
+function union(a, b) {
+  return [...new Set([...(a ?? []), ...b])];
+}
 
 // We create a Promise version of setTimeout
 function delay(ms) {
@@ -455,12 +459,12 @@ function DualClick(single_func, dbl_func) {
 }
 
 // We remove the default download image button
-plot_obj.config.modeBarButtonsToRemove = _.union(
+plot_obj.config.modeBarButtonsToRemove = union(
   plot_obj.config.modeBarButtonsToRemove,
   ["toImage"]
 );
 // We add the custom button to the modebar
-plot_obj.config.modeBarButtonsToAdd = _.union(
+plot_obj.config.modeBarButtonsToAdd = union(
   plot_obj.config.modeBarButtonsToAdd,
   [
     {

--- a/src/js/container.js
+++ b/src/js/container.js
@@ -1,12 +1,64 @@
-// Pluto-agnostic construction of the plot container.
-// Creates the `.plutoplotly-container` element and its child plot div, and
-// stashes the Plotly handle + PLOT div on the container so later code can read
-// them from CONTAINER rather than from shared globals. Only the DOM structure
-// lives here; the per-run lifecycle (AbortController, @bind listener, style,
-// invalidation) stays with the caller for now (see src/main_struct.jl).
-function makeContainer(Plotly, html) {
+// Pluto-agnostic construction and update of the plot container.
+// All per-plot state is stored on the CONTAINER element so the rest of the core
+// (clipboard.js / resizer.js) can read it without shared script-scope globals.
+// Expects in scope: addClipboardFunctionality (clipboard.js),
+// addResizeFunctionality (resizer.js). `html`/`Plotly`/`css` are passed in.
+
+// Build the container element once (only called on first creation; on a
+// reactive re-run the host adapter reuses the existing container).
+function makeContainer(Plotly, html, css) {
   const CONTAINER = html`<div class='plutoplotly-container'></div>`;
   CONTAINER.Plotly = Plotly;
-  CONTAINER.PLOT = CONTAINER.appendChild(html`<div></div>`);
+  // Inject the stylesheet once.
+  CONTAINER.appendChild(html`<style>${css}</style>`);
+  // Child div that holds the actual Plotly plot.
+  const PLOT = (CONTAINER.PLOT = CONTAINER.appendChild(html`<div></div>`));
+  // Controller used to remove event listeners on invalidation.
+  CONTAINER.controller = new AbortController();
+  // Keep supporting @bind with the old API using PLOT.
+  PLOT.addEventListener(
+    "input",
+    (e) => {
+      CONTAINER.value = PLOT.value;
+      if (e.bubbles) {
+        return;
+      }
+      CONTAINER.dispatchEvent(new CustomEvent("input"));
+    },
+    { signal: CONTAINER.controller.signal }
+  );
+  CONTAINER.isPoppedOut = () => CONTAINER.classList.contains("popped-out");
   return CONTAINER;
+}
+
+// Stash the per-plot data on CONTAINER, wire clipboard + resize behaviour, then
+// render and attach the user listeners. Runs on every (re-)render.
+function updatePlotData(CONTAINER, plot_obj, listeners = {}, firstRun = true) {
+  const { Plotly, PLOT } = CONTAINER;
+  CONTAINER.plot_obj = plot_obj;
+  CONTAINER.original_height = plot_obj.layout?.height;
+  CONTAINER.original_width = plot_obj.layout?.width;
+  // Flag: remove the fixed inline height/width after the first resize.
+  CONTAINER.remove_container_size = firstRun;
+  // Fixed height in case the plot sits in a non-fixed-size wrapper (the default).
+  const container_height =
+    CONTAINER.original_height ?? PLOT.container_height ?? 400;
+  CONTAINER.style.height = container_height + "px";
+  addClipboardFunctionality(CONTAINER, firstRun);
+  addResizeFunctionality(CONTAINER, firstRun);
+  return Plotly.react(PLOT, plot_obj).then(() => {
+    const { plotlyListeners = {}, jsListeners = {} } = listeners;
+    for (const [key, listener_vec] of Object.entries(plotlyListeners)) {
+      for (const listener of listener_vec) {
+        PLOT.on(key, listener);
+      }
+    }
+    for (const [key, listener_vec] of Object.entries(jsListeners)) {
+      for (const listener of listener_vec) {
+        PLOT.addEventListener(key, listener, {
+          signal: CONTAINER.controller.signal,
+        });
+      }
+    }
+  });
 }

--- a/src/js/container.js
+++ b/src/js/container.js
@@ -1,0 +1,12 @@
+// Pluto-agnostic construction of the plot container.
+// Creates the `.plutoplotly-container` element and its child plot div, and
+// stashes the Plotly handle + PLOT div on the container so later code can read
+// them from CONTAINER rather than from shared globals. Only the DOM structure
+// lives here; the per-run lifecycle (AbortController, @bind listener, style,
+// invalidation) stays with the caller for now (see src/main_struct.jl).
+function makeContainer(Plotly, html) {
+  const CONTAINER = html`<div class='plutoplotly-container'></div>`;
+  CONTAINER.Plotly = Plotly;
+  CONTAINER.PLOT = CONTAINER.appendChild(html`<div></div>`);
+  return CONTAINER;
+}

--- a/src/js/container.js
+++ b/src/js/container.js
@@ -12,28 +12,17 @@ function makeContainer(Plotly, html, css) {
   // Inject the stylesheet once.
   CONTAINER.appendChild(html`<style>${css}</style>`);
   // Child div that holds the actual Plotly plot.
-  const PLOT = (CONTAINER.PLOT = CONTAINER.appendChild(html`<div></div>`));
-  // Controller used to remove event listeners on invalidation.
-  CONTAINER.controller = new AbortController();
-  // Keep supporting @bind with the old API using PLOT.
-  PLOT.addEventListener(
-    "input",
-    (e) => {
-      CONTAINER.value = PLOT.value;
-      if (e.bubbles) {
-        return;
-      }
-      CONTAINER.dispatchEvent(new CustomEvent("input"));
-    },
-    { signal: CONTAINER.controller.signal }
-  );
+  CONTAINER.PLOT = CONTAINER.appendChild(html`<div></div>`);
   CONTAINER.isPoppedOut = () => CONTAINER.classList.contains("popped-out");
   return CONTAINER;
 }
 
 // Stash the per-plot data on CONTAINER, wire clipboard + resize behaviour, then
-// render and attach the user listeners. Runs on every (re-)render.
-function updatePlotData(CONTAINER, plot_obj, listeners = {}, firstRun = true) {
+// render and attach the user listeners. Runs on every (re-)render. Returns the
+// per-run { controller, resizeObserver } so the host can tear down exactly the
+// resources this run created on invalidation (the CONTAINER itself is reused
+// across reactive re-runs, so these must NOT be stashed on it).
+function updatePlotData(CONTAINER, plot_obj, listeners, firstRun) {
   const { Plotly, PLOT } = CONTAINER;
   CONTAINER.plot_obj = plot_obj;
   CONTAINER.original_height = plot_obj.layout?.height;
@@ -44,9 +33,25 @@ function updatePlotData(CONTAINER, plot_obj, listeners = {}, firstRun = true) {
   const container_height =
     CONTAINER.original_height ?? PLOT.container_height ?? 400;
   CONTAINER.style.height = container_height + "px";
+  // Per-run controller: removes the @bind forwarder + all JS listeners when this
+  // run is invalidated. Recreated every run because the previous run's controller
+  // is aborted on its invalidation.
+  const controller = new AbortController();
+  // Keep supporting @bind with the old API using PLOT.
+  PLOT.addEventListener(
+    "input",
+    (e) => {
+      CONTAINER.value = PLOT.value;
+      if (e.bubbles) {
+        return;
+      }
+      CONTAINER.dispatchEvent(new CustomEvent("input"));
+    },
+    { signal: controller.signal }
+  );
   addClipboardFunctionality(CONTAINER, firstRun);
-  addResizeFunctionality(CONTAINER, firstRun);
-  return Plotly.react(PLOT, plot_obj).then(() => {
+  const resizeObserver = addResizeFunctionality(CONTAINER, firstRun);
+  Plotly.react(PLOT, plot_obj).then(() => {
     const { plotlyListeners = {}, jsListeners = {} } = listeners;
     for (const [key, listener_vec] of Object.entries(plotlyListeners)) {
       for (const listener of listener_vec) {
@@ -55,10 +60,9 @@ function updatePlotData(CONTAINER, plot_obj, listeners = {}, firstRun = true) {
     }
     for (const [key, listener_vec] of Object.entries(jsListeners)) {
       for (const listener of listener_vec) {
-        PLOT.addEventListener(key, listener, {
-          signal: CONTAINER.controller.signal,
-        });
+        PLOT.addEventListener(key, listener, { signal: controller.signal });
       }
     }
   });
+  return { controller, resizeObserver };
 }

--- a/src/js/eslint.config.mjs
+++ b/src/js/eslint.config.mjs
@@ -1,33 +1,37 @@
 // Self-contained ESLint flat config (no npm deps) for the plot-injection scripts.
 //
-// clipboard.js and resizer.js are read by Julia and concatenated into a single
-// <script> that the package injects into the page (see src/show.jl and
-// src/main_struct.jl). They therefore share one lexical scope and rely on names
-// defined by the Julia preamble, the Pluto runtime, lodash-es, and each other.
-// Declaring those names here keeps `no-undef` useful instead of a wall of false
-// positives. This list doubles as the contract a future non-Pluto (e.g. VSCode)
-// host would have to provide.
+// The core files (html.js, container.js, clipboard.js, resizer.js) plus the
+// active adapter (pluto_adapter.js) are read by Julia and concatenated into a
+// single <script> that the package injects into the page (see src/show.jl and
+// src/main_struct.jl). They share one lexical scope: per-plot state lives on the
+// CONTAINER element, and the files call each other's top-level functions. The
+// names below are the cross-file + host contract — declaring them keeps
+// `no-undef` useful and doubles as the contract a future non-Pluto (e.g. VSCode)
+// adapter would have to provide in place of pluto_adapter.js.
 
 const injectedGlobals = {
-  // Julia preamble (src/show.jl + the script blocks in src/main_struct.jl)
+  // Published data + library (Julia preamble in src/show.jl)
   plot_obj: "readonly",
   Plotly: "readonly",
-  CONTAINER: "readonly",
-  PLOT: "readonly",
-  firstRun: "readonly",
-  original_width: "readonly",
-  original_height: "readonly",
-  remove_container_size: "writable", // reassigned by resizer.js / unpop
-  // Pluto runtime
+  plotly_listeners: "readonly",
+  js_listeners: "readonly",
+  // Container stylesheet, bound in src/main_struct.jl
+  css: "readonly",
+  // Provided by html.js (or the host); consumed by the other core files
   html: "readonly",
-  // lodash-es, imported in src/show.jl
-  _: "readonly",
-  // cross-file (clipboard.js <-> resizer.js)
-  CLIPBOARD_HEADER: "readonly",
-  config_spans: "readonly",
+  // Pluto runtime — only pluto_adapter.js touches `invalidation`
+  invalidation: "readonly",
+  // Core cross-file functions (defined in one core file, called from another)
+  makeContainer: "readonly",
+  updatePlotData: "readonly",
+  addClipboardFunctionality: "readonly",
+  addResizeFunctionality: "readonly",
+  getOffsetData: "readonly",
   getSizeData: "readonly",
   computeContainerSize: "readonly",
   computePlotSize: "readonly",
+  changeContainerSize: "readonly",
+  updateFromHeader: "readonly",
 };
 
 const browserGlobals = {

--- a/src/js/html.js
+++ b/src/js/html.js
@@ -1,0 +1,16 @@
+// Minimal tagged-template DOM helper. Replaces Pluto's injected `html`.
+// Declared as `function html` (not `const html`) so it shadows the `html`
+// parameter Pluto injects into the script scope instead of throwing
+// "already declared". Returns the first element child of the parsed fragment;
+// sufficient for the `html`<div …>`` usage in the plot core, not a framework.
+//
+// `document.importNode(..., true)` is REQUIRED: a <template>'s `.content` lives
+// in a separate inert document, so its elements have the wrong `ownerDocument`.
+// Plotly's d3 layer then throws "Cannot read properties of null (reading
+// 'namespaceURI')" inside Plotly.react. importNode adopts the node into the
+// main document (this is what observablehq's / Pluto's `html` does too).
+function html(strings, ...vals) {
+  const t = document.createElement("template");
+  t.innerHTML = strings.reduce((acc, s, i) => acc + String(vals[i - 1]) + s);
+  return document.importNode(t.content.firstElementChild, true);
+}

--- a/src/js/pluto_adapter.js
+++ b/src/js/pluto_adapter.js
@@ -1,0 +1,29 @@
+// The ONLY Pluto-aware file. A VSCode adapter would be its sibling.
+// Expects in closure scope (from the Julia preamble in src/show.jl + the css
+// binding in src/main_struct.jl): plot_obj, Plotly, plotly_listeners,
+// js_listeners, html, css; and Pluto's injected `this` / `invalidation`.
+// `CONTAINER` is returned to Pluto by `return CONTAINER` in src/show.jl.
+
+const firstRun = this ? false : true;
+const CONTAINER = this ?? makeContainer(Plotly, html, css);
+
+// `PLOT` is a DOCUMENTED in-scope variable for user listeners
+// (add_js_listener! / add_plotly_listener! docstrings). Keep it bound so existing
+// user listener code referencing bare `PLOT` keeps working.
+const PLOT = CONTAINER.PLOT;
+
+updatePlotData(
+  CONTAINER,
+  plot_obj,
+  { plotlyListeners: plotly_listeners, jsListeners: js_listeners },
+  firstRun
+);
+
+invalidation.then(() => {
+  // Remove all plotly listeners
+  PLOT.removeAllListeners();
+  // Remove all JS listeners
+  CONTAINER.controller.abort();
+  // Remove the resizeObserver
+  CONTAINER.resizeObserver.disconnect();
+});

--- a/src/js/pluto_adapter.js
+++ b/src/js/pluto_adapter.js
@@ -12,7 +12,9 @@ const CONTAINER = this ?? makeContainer(Plotly, html, css);
 // user listener code referencing bare `PLOT` keeps working.
 const PLOT = CONTAINER.PLOT;
 
-updatePlotData(
+// Capture THIS run's teardown handles; CONTAINER is reused across re-runs, so
+// cleaning up these locals (not CONTAINER.*) avoids clobbering the next run.
+const { controller, resizeObserver } = updatePlotData(
   CONTAINER,
   plot_obj,
   { plotlyListeners: plotly_listeners, jsListeners: js_listeners },
@@ -22,8 +24,8 @@ updatePlotData(
 invalidation.then(() => {
   // Remove all plotly listeners
   PLOT.removeAllListeners();
-  // Remove all JS listeners
-  CONTAINER.controller.abort();
-  // Remove the resizeObserver
-  CONTAINER.resizeObserver.disconnect();
+  // Remove the @bind forwarder + all JS listeners added this run
+  controller.abort();
+  // Remove this run's resizeObserver
+  resizeObserver.disconnect();
 });

--- a/src/js/resizer.js
+++ b/src/js/resizer.js
@@ -1,12 +1,12 @@
-// Injected as part of the plot <script> (see src/show.jl); runs in the shared
-// scope of the concatenated script. Expects to already be in scope:
-//   Julia preamble: Plotly, CONTAINER, PLOT, firstRun
-//   on CONTAINER  : original_width, original_height, remove_container_size
-//   clipboard.js  : CLIPBOARD_HEADER, config_spans
-// Exposes for clipboard.js: getSizeData, computeContainerSize, computePlotSize,
-// and the resizeObserver.
+// Resize behaviour for the plot. The size helpers are pure-ish functions that
+// take the CONTAINER explicitly; the stateful part (header onblur wiring + the
+// ResizeObserver) is wrapped in addResizeFunctionality so nothing leaks into the
+// shared script scope. Reads CONTAINER.CLIPBOARD_HEADER / CONTAINER.config_spans
+// (set by clipboard.js); exposes getSizeData / computeContainerSize /
+// computePlotSize for clipboard.js.
 
-function getOffsetData(el) {
+function getOffsetData(CONTAINER, el) {
+  const PLOT = CONTAINER.PLOT;
   let cs = window.getComputedStyle(el, null);
   const odata = {
     padding: {
@@ -35,23 +35,19 @@ function getOffsetData(el) {
   }
   return odata;
 }
-function getSizeData() {
+function getSizeData(CONTAINER) {
+  const PLOT = CONTAINER.PLOT;
   const data = {
-    plot_pad: getOffsetData(PLOT),
+    plot_pad: getOffsetData(CONTAINER, PLOT),
     plot_rect: PLOT.getBoundingClientRect(),
-    container_pad: getOffsetData(CONTAINER),
+    container_pad: getOffsetData(CONTAINER, CONTAINER),
     container_rect: CONTAINER.getBoundingClientRect(),
   };
   return data;
 }
-function computeContainerSize({ width, height }, sizeData = getSizeData()) {
-  const computed_size = computePlotSize(sizeData);
+function computeContainerSize(CONTAINER, { width, height }, sizeData = getSizeData(CONTAINER)) {
+  const computed_size = computePlotSize(CONTAINER, sizeData);
   const offsets = computed_size.offsets;
-
-  const plot_data = {
-    width: width ?? computed_size.width,
-    height: height ?? computed_size.height,
-  };
 
   return {
     width: (width ?? computed_size.width) + offsets.width,
@@ -61,12 +57,12 @@ function computeContainerSize({ width, height }, sizeData = getSizeData()) {
 }
 
 // This function will change the container size so that the resulting plot will be matching the provided specs
-function changeContainerSize({ width, height }, sizeData = getSizeData()) {
+function changeContainerSize(CONTAINER, { width, height }, sizeData = getSizeData(CONTAINER)) {
   if (!CONTAINER.isPoppedOut()) {
     return;
   }
 
-  const csz = computeContainerSize({ width, height }, sizeData);
+  const csz = computeContainerSize(CONTAINER, { width, height }, sizeData);
 
   if (csz.noChange) {
     return
@@ -77,24 +73,15 @@ function changeContainerSize({ width, height }, sizeData = getSizeData()) {
   }
 }
 // We now create the function that will update the plot based on the values specified
-function updateFromHeader() {
+function updateFromHeader(CONTAINER) {
   const header_data = {
-    height: config_spans.height.ui_value,
-    width: config_spans.width.ui_value,
+    height: CONTAINER.config_spans.height.ui_value,
+    width: CONTAINER.config_spans.width.ui_value,
   };
-  changeContainerSize(header_data);
-}
-// We assign this function to the onblur event of width and height
-if (firstRun) {
-  for (const container of Object.values(config_spans)) {
-    container.ui_span.onblur = (e) => {
-      container.ui_value = container.ui_span.textContent;
-      updateFromHeader();
-    };
-  }
+  changeContainerSize(CONTAINER, header_data);
 }
 // This function computes the plot size to use for relayout as a function of the container size
-function computePlotSize(data = getSizeData()) {
+function computePlotSize(CONTAINER, data = getSizeData(CONTAINER)) {
   // Remove Padding
   const { container_pad, plot_pad, container_rect } = data;
   const offsets = {
@@ -119,36 +106,51 @@ function computePlotSize(data = getSizeData()) {
   return sz;
 }
 
-// Create the resizeObserver to make the plot even more responsive! :magic:
-const resizeObserver = new ResizeObserver((entries) => {
-  const sizeData = getSizeData();
-  const {container_rect, container_pad} = sizeData;
-  let plot_size = computePlotSize(sizeData);
-  // We save the height in the PLOT object
-  PLOT.container_height = container_rect.height;
-  // We deal with some stuff if the container is poppped
-  CLIPBOARD_HEADER.style.width = container_rect.width + "px";
-  CLIPBOARD_HEADER.style.left = container_rect.left + "px";
-  config_spans.height.ui_value = plot_size.height;
-  config_spans.width.ui_value = plot_size.width;
-  /*
+// Wire the header onblur handlers (first run only) and create the ResizeObserver
+// that keeps the plot responsive. The observer is stashed on CONTAINER so the
+// host adapter can disconnect it on invalidation.
+function addResizeFunctionality(CONTAINER, firstRun) {
+  const { Plotly, PLOT } = CONTAINER;
+  // We assign updateFromHeader to the onblur event of width and height
+  if (firstRun) {
+    for (const container of Object.values(CONTAINER.config_spans)) {
+      container.ui_span.onblur = (e) => {
+        container.ui_value = container.ui_span.textContent;
+        updateFromHeader(CONTAINER);
+      };
+    }
+  }
+  // Create the resizeObserver to make the plot even more responsive! :magic:
+  const resizeObserver = (CONTAINER.resizeObserver = new ResizeObserver((entries) => {
+    const sizeData = getSizeData(CONTAINER);
+    const { container_rect } = sizeData;
+    let plot_size = computePlotSize(CONTAINER, sizeData);
+    // We save the height in the PLOT object
+    PLOT.container_height = container_rect.height;
+    // We deal with some stuff if the container is poppped
+    CONTAINER.CLIPBOARD_HEADER.style.width = container_rect.width + "px";
+    CONTAINER.CLIPBOARD_HEADER.style.left = container_rect.left + "px";
+    CONTAINER.config_spans.height.ui_value = plot_size.height;
+    CONTAINER.config_spans.width.ui_value = plot_size.width;
+    /*
 		The addition of the invalid argument `plutoresize` seems to fix the problem with calling `relayout` simply with `{autosize: true}` as update breaking mouse relayout events tracking.
 		See https://github.com/plotly/plotly.js/issues/6156 for details
 		*/
-  let config = {
-    // If this is popped out, we ignore the original width/height
-    width: (CONTAINER.isPoppedOut() ? undefined : CONTAINER.original_width) ?? plot_size.width,
-    height: (CONTAINER.isPoppedOut() ? undefined : CONTAINER.original_height) ?? plot_size.height,
-    plutoresize: true,
-  };
-  Plotly.relayout(PLOT, config).then(() => {
-    if (CONTAINER.remove_container_size && !CONTAINER.isPoppedOut()) {
-      // This is needed to avoid the first resize upon plot creation to already be without a fixed height
-      CONTAINER.style.height = "";
-      CONTAINER.style.width = "";
-      CONTAINER.remove_container_size = false;
-    }
-  });
-});
+    let config = {
+      // If this is popped out, we ignore the original width/height
+      width: (CONTAINER.isPoppedOut() ? undefined : CONTAINER.original_width) ?? plot_size.width,
+      height: (CONTAINER.isPoppedOut() ? undefined : CONTAINER.original_height) ?? plot_size.height,
+      plutoresize: true,
+    };
+    Plotly.relayout(PLOT, config).then(() => {
+      if (CONTAINER.remove_container_size && !CONTAINER.isPoppedOut()) {
+        // This is needed to avoid the first resize upon plot creation to already be without a fixed height
+        CONTAINER.style.height = "";
+        CONTAINER.style.width = "";
+        CONTAINER.remove_container_size = false;
+      }
+    });
+  }));
 
-resizeObserver.observe(CONTAINER);
+  resizeObserver.observe(CONTAINER);
+}

--- a/src/js/resizer.js
+++ b/src/js/resizer.js
@@ -1,7 +1,7 @@
 // Injected as part of the plot <script> (see src/show.jl); runs in the shared
 // scope of the concatenated script. Expects to already be in scope:
-//   Julia preamble: Plotly, CONTAINER, PLOT, firstRun, original_width,
-//                   original_height, remove_container_size
+//   Julia preamble: Plotly, CONTAINER, PLOT, firstRun
+//   on CONTAINER  : original_width, original_height, remove_container_size
 //   clipboard.js  : CLIPBOARD_HEADER, config_spans
 // Exposes for clipboard.js: getSizeData, computeContainerSize, computePlotSize,
 // and the resizeObserver.
@@ -137,16 +137,16 @@ const resizeObserver = new ResizeObserver((entries) => {
 		*/
   let config = {
     // If this is popped out, we ignore the original width/height
-    width: (CONTAINER.isPoppedOut() ? undefined : original_width) ?? plot_size.width,
-    height: (CONTAINER.isPoppedOut() ? undefined : original_height) ?? plot_size.height,
+    width: (CONTAINER.isPoppedOut() ? undefined : CONTAINER.original_width) ?? plot_size.width,
+    height: (CONTAINER.isPoppedOut() ? undefined : CONTAINER.original_height) ?? plot_size.height,
     plutoresize: true,
   };
   Plotly.relayout(PLOT, config).then(() => {
-    if (remove_container_size && !CONTAINER.isPoppedOut()) {
+    if (CONTAINER.remove_container_size && !CONTAINER.isPoppedOut()) {
       // This is needed to avoid the first resize upon plot creation to already be without a fixed height
       CONTAINER.style.height = "";
       CONTAINER.style.width = "";
-      remove_container_size = false;
+      CONTAINER.remove_container_size = false;
     }
   });
 });

--- a/src/js/resizer.js
+++ b/src/js/resizer.js
@@ -107,8 +107,9 @@ function computePlotSize(CONTAINER, data = getSizeData(CONTAINER)) {
 }
 
 // Wire the header onblur handlers (first run only) and create the ResizeObserver
-// that keeps the plot responsive. The observer is stashed on CONTAINER so the
-// host adapter can disconnect it on invalidation.
+// that keeps the plot responsive. Returns the observer so the host adapter can
+// disconnect this run's observer on invalidation (it must not be stashed on the
+// reused CONTAINER, or a later run would clobber the reference).
 function addResizeFunctionality(CONTAINER, firstRun) {
   const { Plotly, PLOT } = CONTAINER;
   // We assign updateFromHeader to the onblur event of width and height
@@ -121,7 +122,7 @@ function addResizeFunctionality(CONTAINER, firstRun) {
     }
   }
   // Create the resizeObserver to make the plot even more responsive! :magic:
-  const resizeObserver = (CONTAINER.resizeObserver = new ResizeObserver((entries) => {
+  const resizeObserver = new ResizeObserver(() => {
     const sizeData = getSizeData(CONTAINER);
     const { container_rect } = sizeData;
     let plot_size = computePlotSize(CONTAINER, sizeData);
@@ -150,7 +151,8 @@ function addResizeFunctionality(CONTAINER, firstRun) {
         CONTAINER.remove_container_size = false;
       }
     });
-  }));
+  });
 
   resizeObserver.observe(CONTAINER);
+  return resizeObserver;
 }

--- a/src/main_struct.jl
+++ b/src/main_struct.jl
@@ -1,16 +1,19 @@
 const _container_css = read(joinpath(@__DIR__, "js", "container.css"), String)
 const html_script = htl_js(read(joinpath(@__DIR__, "js", "html.js"), String))
+const container_script = htl_js(read(joinpath(@__DIR__, "js", "container.js"), String))
 const clipboard_script = htl_js(read(joinpath(@__DIR__, "js", "clipboard.js"), String))
 const resizer_script = htl_js(read(joinpath(@__DIR__, "js", "resizer.js"), String))
 
 const _default_script_contents = htl_js.([
 	# Provide our own `html` DOM helper, shadowing Pluto's injected one (see html.js)
 	html_script,
+	# makeContainer(): Pluto-agnostic container/PLOT construction (see container.js)
+	container_script,
 	"""
 	// Flag to check if this cell was  manually ran or reactively ran
 	const firstRun = this ? false : true
-	const CONTAINER = this ?? html`<div class='plutoplotly-container'>`
-	const PLOT = CONTAINER.querySelector('.js-plotly-plot') ?? CONTAINER.appendChild(html`<div>`)
+	const CONTAINER = this ?? makeContainer(Plotly, html)
+	const PLOT = CONTAINER.PLOT
 	const parent = CONTAINER.parentElement
 	// We use a controller to remove event listeners upon invalidation
 	const controller = new AbortController()

--- a/src/main_struct.jl
+++ b/src/main_struct.jl
@@ -35,12 +35,15 @@ const _default_script_contents = htl_js.([
 	`)
 	"""),
 	"""
-	let original_height = plot_obj.layout.height
-	let original_width = plot_obj.layout.width
+	// Stash the per-plot data on CONTAINER so clipboard.js/resizer.js read it
+	// from there instead of from shared script-scope globals.
+	CONTAINER.plot_obj = plot_obj
+	CONTAINER.original_height = plot_obj.layout.height
+	CONTAINER.original_width = plot_obj.layout.width
 	// For the height we have to also put a fixed value in case the plot is put on a non-fixed-size container (like the default wrapper)
 	// We define a variable to check whether we still have to remove the fixed height
-	let remove_container_size = firstRun
-	let container_height = original_height ?? PLOT.container_height ?? 400
+	CONTAINER.remove_container_size = firstRun
+	let container_height = CONTAINER.original_height ?? PLOT.container_height ?? 400
 	CONTAINER.style.height = container_height + 'px'
 	""",
 	clipboard_script,

--- a/src/main_struct.jl
+++ b/src/main_struct.jl
@@ -1,8 +1,11 @@
 const _container_css = read(joinpath(@__DIR__, "js", "container.css"), String)
+const html_script = htl_js(read(joinpath(@__DIR__, "js", "html.js"), String))
 const clipboard_script = htl_js(read(joinpath(@__DIR__, "js", "clipboard.js"), String))
 const resizer_script = htl_js(read(joinpath(@__DIR__, "js", "resizer.js"), String))
 
 const _default_script_contents = htl_js.([
+	# Provide our own `html` DOM helper, shadowing Pluto's injected one (see html.js)
+	html_script,
 	"""
 	// Flag to check if this cell was  manually ran or reactively ran
 	const firstRun = this ? false : true

--- a/src/main_struct.jl
+++ b/src/main_struct.jl
@@ -3,82 +3,21 @@ const html_script = htl_js(read(joinpath(@__DIR__, "js", "html.js"), String))
 const container_script = htl_js(read(joinpath(@__DIR__, "js", "container.js"), String))
 const clipboard_script = htl_js(read(joinpath(@__DIR__, "js", "clipboard.js"), String))
 const resizer_script = htl_js(read(joinpath(@__DIR__, "js", "resizer.js"), String))
+const pluto_adapter_script = htl_js(read(joinpath(@__DIR__, "js", "pluto_adapter.js"), String))
 
 const _default_script_contents = htl_js.([
 	# Provide our own `html` DOM helper, shadowing Pluto's injected one (see html.js)
 	html_script,
-	# makeContainer(): Pluto-agnostic container/PLOT construction (see container.js)
+	# Pluto-agnostic core: makeContainer/updatePlotData (container.js),
+	# addClipboardFunctionality (clipboard.js), addResizeFunctionality (resizer.js).
 	container_script,
-	"""
-	// Flag to check if this cell was  manually ran or reactively ran
-	const firstRun = this ? false : true
-	const CONTAINER = this ?? makeContainer(Plotly, html)
-	const PLOT = CONTAINER.PLOT
-	const parent = CONTAINER.parentElement
-	// We use a controller to remove event listeners upon invalidation
-	const controller = new AbortController()
-	// We have to add this to keep supporting @bind with the old API using PLOT
-	PLOT.addEventListener('input', (e) => {
-		CONTAINER.value = PLOT.value
-		if (e.bubbles) {
-			return
-		}
-		CONTAINER.dispatchEvent(new CustomEvent('input'))
-	}, { signal: controller.signal })
-	""",
-	JS("""
-		// This creates the style subdiv on first run
-		firstRun && CONTAINER.appendChild(html`
-		<style>
-	""" * _container_css * """
-	</style>
-	`)
-	"""),
-	"""
-	// Stash the per-plot data on CONTAINER so clipboard.js/resizer.js read it
-	// from there instead of from shared script-scope globals.
-	CONTAINER.plot_obj = plot_obj
-	CONTAINER.original_height = plot_obj.layout.height
-	CONTAINER.original_width = plot_obj.layout.width
-	// For the height we have to also put a fixed value in case the plot is put on a non-fixed-size container (like the default wrapper)
-	// We define a variable to check whether we still have to remove the fixed height
-	CONTAINER.remove_container_size = firstRun
-	let container_height = CONTAINER.original_height ?? PLOT.container_height ?? 400
-	CONTAINER.style.height = container_height + 'px'
-	""",
 	clipboard_script,
 	resizer_script,
-	"""
-
-	Plotly.react(PLOT, plot_obj).then(() => {
-		// Assign the Plotly event listeners
-		for (const [key, listener_vec] of Object.entries(plotly_listeners)) {
-			for (const listener of listener_vec) {
-				PLOT.on(key, listener)
-			}
-		}
-		// Assign the JS event listeners
-		for (const [key, listener_vec] of Object.entries(js_listeners)) {
-			for (const listener of listener_vec) {
-				PLOT.addEventListener(key, listener, {
-					signal: controller.signal
-				})
-			}
-		}
-	}
-	)
-	""",
-	"""
-
-	invalidation.then(() => {
-		// Remove all plotly listeners
-		PLOT.removeAllListeners()
-		// Remove all JS listeners
-		controller.abort()
-		// Remove the resizeObserver
-		resizeObserver.disconnect()
-	})
-	""",
+	# The container stylesheet, bound to `css` for the adapter's makeContainer call.
+	JS("const css = `" * _container_css * "`"),
+	# The only Pluto-aware piece: wires `this`/`invalidation`/published data into
+	# the core (see pluto_adapter.js). A vscode_adapter.js would replace just this.
+	pluto_adapter_script,
 ])
 
 """

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,20 +1,21 @@
 function _show(pp::PlutoPlot; script_id = "pluto-plotly-div", ver = get_plotly_version())
 @htl """
 	<script id=$(script_id)>
-        // We add lodash as an import (currently this makes PlutoPlotly not work offline, to be fixed in a next release)
-        const _ = await import('https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm')
-
 		// We start by putting all the variable interpolation here at the beginning
 		// We have to convert all typedarrays in the layout to normal arrays. See Issue #25
-		// We use lodash for this for compactness
 		function removeTypedArray(o) {
-			return _.isTypedArray(o) ? Array.from(o) :
-			_.isPlainObject(o) ? _.mapValues(o, removeTypedArray) : 
-			o
+			if (ArrayBuffer.isView(o)) return Array.from(o)
+			if (o !== null && typeof o === 'object' && !Array.isArray(o)) {
+				const r = {}
+				for (const [k, v] of Object.entries(o)) r[k] = removeTypedArray(v)
+				return r
+			}
+			return o
 		}
 
 		// Publish the plot object to JS
-		let plot_obj = _.update($(maybe_publish_to_js(_process_with_names(pp))), "layout", removeTypedArray)
+		let plot_obj = $(maybe_publish_to_js(_process_with_names(pp)))
+		plot_obj.layout = removeTypedArray(plot_obj.layout)
 		// Get the plotly listeners
 		const plotly_listeners = $(pp.plotly_listeners)
 		// Get the JS listeners


### PR DESCRIPTION
## What & why

Phase A of decoupling the plot's JavaScript from Pluto. This continues the JS-extraction work from #67: the goal is a Pluto-agnostic plot core so a future non-Pluto host (e.g. VSCode) only needs to provide its own thin adapter, and so the JS can be linted/reviewed as real files instead of Julia string literals.

No behaviour change in Pluto — rendering, copy-to-clipboard, resize, pop-out and `@bind` round-trip all work as before.

## How

- **Per-plot state lives on the `CONTAINER` element**, not in the shared concatenated-script scope. `clipboard.js` and `resizer.js` are wrapped in `addClipboardFunctionality(CONTAINER, firstRun)` / `addResizeFunctionality(CONTAINER, firstRun)` and read every value from `CONTAINER.*`; the size helpers (`getSizeData`/`computeContainerSize`/`computePlotSize`/…) take `CONTAINER` explicitly.
- **`container.js`** gains `updatePlotData` (stash data → wire clipboard+resize → `Plotly.react` → attach listeners) alongside an expanded `makeContainer` (style injection, `AbortController`, `@bind` listener, `isPoppedOut`).
- **New `pluto_adapter.js`** is the *only* Pluto-aware file (`this` / `invalidation` / published data). A `vscode_adapter.js` would simply be its sibling.
- **`main_struct.jl`** now just concatenates the core files + a `css` binding + the active adapter; the inline glue is gone.
- **lodash removed** — the last CDN/offline-blocking import is dropped; `removeTypedArray` and a small `union` helper replace the 6 lodash call sites.
- **`html.js`** provides a minimal tagged-template DOM helper, shadowing Pluto's injected `html` (a step toward host-independence).
- **eslint** config + the cross-file/host "contract" globals list kept in sync.

## Verification

Checked live in a Pluto notebook (27 plots in `basic_tests.jl`):

- 27/27 plots render identically, 0 console errors.
- Pop-out / unpop, resize, clipboard header span editing, Set/Unset, Download Image all work.
- No names leak to `window` (the core is fully function-scoped).
- Reactive re-run reuses the existing container (no leak/duplication); invalidation disconnects the resize observer and aborts listeners.
- Render timing unchanged within measurement noise (manual rerun ~0.86 s, in-place slider update ~0.12 s; equal to the pre-refactor branch).

## Notes

- The blob/data-URL module loader and the actual VSCode adapter are intentionally out of scope (parked for the next phase).
